### PR TITLE
Added soft limit for entity metric count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.1.2 - 2018-09-14
 ### Added
-- Logic to enforce a soft limit on the number of metrics that can be collect. If the number of metrics per Entity exceeds this limit a warning will be logged.
+- Logic to enforce a soft limit on the number of metrics that can be collect. If the number of metrics per Entity exceeds this limit the Entity will not be reported to NR.
 
 ## 0.1.1 - 2018-09-13
 ### Changed

--- a/src/jmx_test.go
+++ b/src/jmx_test.go
@@ -7,15 +7,9 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/integration"
 )
 
-func Test_checkMetricList_NoPanic(t *testing.T) {
+func Test_checkMetricList(t *testing.T) {
 	// Ensure we hit the
-	args.MetricLimit = 1
-
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("Unexpected panic: %s", r)
-		}
-	}()
+	args.MetricLimit = 2
 
 	i, err := integration.New("kafka", "1.0.0")
 	if err != nil {
@@ -23,14 +17,33 @@ func Test_checkMetricList_NoPanic(t *testing.T) {
 		t.FailNow()
 	}
 
-	e, err := i.Entity("test", "domain")
+	e1, err := i.Entity("test_1", "domain")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 		t.FailNow()
 	}
 
-	set := e.NewMetricSet("testSample")
-	set.SetMetric("new_metric", 4, metric.GAUGE)
+	set1 := e1.NewMetricSet("testSample")
+	set1.SetMetric("new_metric", 4, metric.GAUGE)
 
-	checkMetricLimit(i.Entities)
+	e2, err := i.Entity("test_2", "domain")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+		t.FailNow()
+	}
+
+	set2 := e2.NewMetricSet("testSample")
+	set2.SetMetric("new_metric", 4, metric.GAUGE)
+	set2.SetMetric("other_metric", 5, metric.GAUGE)
+
+	out := checkMetricLimit(i.Entities)
+
+	if length := len(out); length != 1 {
+		t.Errorf("Expected 1 entity got %d", length)
+		t.FailNow()
+	}
+
+	if out[0] != e1 {
+		t.Errorf("Expected entity '%+v' got '%+v'", e1, out[0])
+	}
 }


### PR DESCRIPTION
#### Description of the changes

Added a configurable metric limit that will log a warning if any entity has more than that limits worth of attributes across all of it's metric sets.

#### PR Review Checklist
### Author

- [X] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [X] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
