### PR TITLE
Fixed case with colon in bean query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.1.5 - 2018-09-20
-### Added
+### Fixed
 - Fixed bug with parsing JMX queries
 
 ## 0.1.4 - 2018-09-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.5 - 2018-09-20
+### Added
+- Fixed bug with parsing JMX queries
 
 ## 0.1.4 - 2018-09-19
 ### Added

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -24,7 +24,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.jmx"
-	integrationVersion = "0.1.4"
+	integrationVersion = "0.1.5"
 )
 
 var (

--- a/src/request.go
+++ b/src/request.go
@@ -245,7 +245,7 @@ func getKeyProperties(keyProperties string) (map[string]string, error) {
 // Convenience function to split the domain:query string
 // into domain and query
 func splitBeanName(bean string) (string, string, error) {
-	domainQuery := strings.Split(bean, ":")
+	domainQuery := strings.SplitN(bean, ":", 2)
 	if len(domainQuery) != 2 {
 		return "", "", fmt.Errorf("invalid domain:bean string %s", bean)
 	}

--- a/src/request_test.go
+++ b/src/request_test.go
@@ -135,6 +135,7 @@ func TestSplitBeanName(t *testing.T) {
 	}{
 		{"java.lang:test=test", "java.lang", "test=test"},
 		{"java.lang:test=test,test2=test2", "java.lang", "test=test,test2=test2"},
+		{`java.lang:test=test,test2="test:test"`, "java.lang", `test=test,test2="test:test"`},
 	}
 
 	for _, tc := range testCases {
@@ -143,7 +144,7 @@ func TestSplitBeanName(t *testing.T) {
 			t.Error(err)
 			t.FailNow()
 		}
-		if out1 != tc.expectedOut1 && out2 != tc.expectedOut2 {
+		if out1 != tc.expectedOut1 || out2 != tc.expectedOut2 {
 			t.Errorf("Expected %s and %s, got %s and %s", out1, out2, tc.expectedOut1, tc.expectedOut2)
 		}
 	}


### PR DESCRIPTION
#### Description of the changes

A customer experienced a bug where a colon in the query would cause a failure. This ensures that the parsing logic won't fail with an extra colon.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
