### PR TITLE
Added remote flag for jBoss6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.3 - 2019-03-18
+### Added
+- Added remote option to use remote URL connections. Format: service:jmx:remoting-jmx://host:port
+
 ## 1.0.2 - 2019-02-13
 ### Added
 - Added SSL option to Jmx.Open

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Information on configuring JMX can be found [here](https://docs.oracle.com/javas
 - extract `jmx-definition.yml` and `/bin` directory into `/var/db/newrelic-infra/newrelic-integrations`
 - add execute permissions for the binary file `nr-jmx` (if required)
 - extract `jmx-config.yml.sample` into `/etc/newrelic-infra/integrations.d`
-- install [`nrjmx` tool](https://github.com/newrelic/nrjmx) 
+- install [`nrjmx` tool](https://github.com/newrelic/nrjmx) (Note: for the remoting-jmx URL use the 1.2.0 version or higher.)
 
 ## Usage
 

--- a/jmx-ssl-config.yml.sample
+++ b/jmx-ssl-config.yml.sample
@@ -8,7 +8,6 @@ instances:
       jmx_port: 9999
       jmx_user: admin
       jmx_pass: admin
-      jmx_remote: false
       key_store: /etc/pki/JMXClientKeyStore.key
       key_store_password: password
       trust_store: /etc/pki/JMXClientTrustStore.key

--- a/jmx-ssl-config.yml.sample
+++ b/jmx-ssl-config.yml.sample
@@ -8,6 +8,7 @@ instances:
       jmx_port: 9999
       jmx_user: admin
       jmx_pass: admin
+      jmx_remote: false
       key_store: /etc/pki/JMXClientKeyStore.key
       key_store_password: password
       trust_store: /etc/pki/JMXClientTrustStore.key

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -35,9 +35,9 @@ const (
 var (
 	args argumentList
 
-	jmxOpenFunc        = jmx.OpenWithParameters
-	jmxCloseFunc       = jmx.Close
-	jmxQueryFunc       = jmx.Query
+	jmxOpenFunc  = jmx.OpenWithParameters
+	jmxCloseFunc = jmx.Close
+	jmxQueryFunc = jmx.Query
 )
 
 func main() {

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -35,7 +35,7 @@ const (
 var (
 	args argumentList
 
-	jmxOpenFunc  = jmx.OpenWithParameters
+	jmxOpenFunc  = jmx.Open
 	jmxCloseFunc = jmx.Close
 	jmxQueryFunc = jmx.Query
 )

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -17,6 +17,7 @@ type argumentList struct {
 	JmxPort            string `default:"9999" help:"The port JMX is running on"`
 	JmxUser            string `default:"admin" help:"The username for the JMX connection"`
 	JmxPass            string `default:"admin" help:"The password for the JMX connection"`
+	JmxRemote          bool   `default:"false" help:"When activated uses the JMX remote url connection format"`
 	KeyStore           string `default:"" help:"The location for the keystore containing JMX Client's SSL certificate"`
 	KeyStorePassword   string `default:"" help:"Password for the SSL Key Store"`
 	TrustStore         string `default:"" help:"The location for the keystore containing JMX Server's SSL certificate"`
@@ -34,8 +35,7 @@ const (
 var (
 	args argumentList
 
-	jmxOpenFunc        = jmx.Open
-	jmxOpenWithSSLFunc = jmx.OpenWithSSL
+	jmxOpenFunc        = jmx.OpenWithParameters
 	jmxCloseFunc       = jmx.Close
 	jmxQueryFunc       = jmx.Query
 )
@@ -49,25 +49,20 @@ func main() {
 	}
 	log.SetupLogging(args.Verbose)
 
+	options := make([]jmx.Option, 0)
+	if args.JmxRemote {
+		options = append(options, jmx.WithRemoteProtocol())
+	}
 	if args.KeyStore != "" && args.KeyStorePassword != "" && args.TrustStore != "" && args.TrustStorePassword != "" {
-		// Open a JMX with SSL connection
-		if err := jmxOpenWithSSLFunc(args.JmxHost, args.JmxPort, args.JmxUser, args.JmxPass, args.KeyStore, args.KeyStorePassword, args.TrustStore, args.TrustStorePassword); err != nil {
-			log.Error(
-				"Failed to open JMX connection (host: %s, port: %s, user: %s, pass: %s, keyStore: %s, keyStorePassword: %s, trustStore: %s, trustStorePassword: %s): %s",
-				args.JmxHost, args.JmxPort, args.JmxUser, args.JmxPass, args.KeyStore, args.KeyStorePassword, args.TrustStore, args.TrustStorePassword, err,
-			)
-			os.Exit(1)
-		}
-	} else {
-
-		// Open a JMX connection
-		if err := jmxOpenFunc(args.JmxHost, args.JmxPort, args.JmxUser, args.JmxPass); err != nil {
-			log.Error(
-				"Failed to open JMX connection (host: %s, port: %s, user: %s, pass: %s): %s",
-				args.JmxHost, args.JmxPort, args.JmxUser, args.JmxPass, err,
-			)
-			os.Exit(1)
-		}
+		ssl := jmx.WithSSL(args.KeyStore, args.KeyStorePassword, args.TrustStore, args.TrustStorePassword)
+		options = append(options, ssl)
+	}
+	if err := jmxOpenFunc(args.JmxHost, args.JmxPort, args.JmxUser, args.JmxPass, options...); err != nil {
+		log.Error(
+			"Failed to open JMX connection (host: %s, port: %s, user: %s, pass: %s, keyStore: %s, keyStorePassword: %s, trustStore: %s, trustStorePassword: %s, remote: %t): %s",
+			args.JmxHost, args.JmxPort, args.JmxUser, args.JmxPass, args.KeyStore, args.KeyStorePassword, args.TrustStore, args.TrustStorePassword, args.JmxRemote, err,
+		)
+		os.Exit(1)
 	}
 
 	// Ensure a collection file is specified

--- a/src/request_test.go
+++ b/src/request_test.go
@@ -275,7 +275,7 @@ func TestHandleResponse(t *testing.T) {
 
 	jsonbytes, _ := i.MarshalJSON()
 
-	expectedMarshalled := `{"name":"jmx","protocol_version":"2","integration_version":"0.1.0","data":[{"entity":{"name":"test.domain","type":"domain"},"metrics":[],"inventory":{},"events":[]}]}`
+	expectedMarshalled := `{"name":"jmx","protocol_version":"3","integration_version":"0.1.0","data":[{"entity":{"name":"test.domain","type":"domain","id_attributes":[]},"metrics":[],"inventory":{},"events":[]}]}`
 
 	if string(jsonbytes) != expectedMarshalled {
 		t.Error("Failed to get expected marshalled json")

--- a/vendor/github.com/newrelic/infra-integrations-sdk/integration/integration.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/integration/integration.go
@@ -25,7 +25,7 @@ const (
 
 // NR infrastructure agent protocol version
 const (
-	protocolVersion = "2"
+	protocolVersion = "3"
 )
 
 // Integration defines the format of the output JSON that integrations will return for protocol 2.
@@ -41,6 +41,20 @@ type Integration struct {
 	writer             io.Writer
 	logger             log.Logger
 	args               interface{}
+}
+
+// IDAttribute is a Key Value struct which is used to have uniqueness during the entity Key resolution.
+type IDAttribute struct {
+	Key   string
+	Value string
+}
+
+// NewIDAttribute creates new identifier attribute.
+func NewIDAttribute(key, value string) IDAttribute {
+	return IDAttribute{
+		Key:   key,
+		Value: value,
+	}
 }
 
 // New creates new integration with sane default values.
@@ -118,7 +132,7 @@ func (i *Integration) LocalEntity() *Entity {
 }
 
 // Entity method creates or retrieves an already created entity.
-func (i *Integration) Entity(name, namespace string) (e *Entity, err error) {
+func (i *Integration) Entity(name, namespace string, idAttributes ...IDAttribute) (e *Entity, err error) {
 	i.locker.Lock()
 	defer i.locker.Unlock()
 
@@ -129,7 +143,7 @@ func (i *Integration) Entity(name, namespace string) (e *Entity, err error) {
 		}
 	}
 
-	e, err = newEntity(name, namespace, i.storer, i.addHostnameToMeta)
+	e, err = newEntity(name, namespace, i.storer, i.addHostnameToMeta, idAttributes...)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/newrelic/infra-integrations-sdk/jmx/jmx.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/jmx/jmx.go
@@ -39,46 +39,82 @@ const (
 	jmxLineBuffer = 4 * 1024 * 1024 // Max 4MB per line. If single lines are outputting more JSON than that, we likely need smaller-scoped JMX queries
 )
 
-func getCommand(hostname, port, username, password string) []string {
-	var cliCommand []string
-
-	if os.Getenv("NR_JMX_TOOL") != "" {
-		cliCommand = strings.Split(os.Getenv("NR_JMX_TOOL"), " ")
-	} else {
-		cliCommand = []string{jmxCommand}
-	}
-
-	cliCommand = append(cliCommand, "--hostname", hostname, "--port", port)
-	if username != "" && password != "" {
-		cliCommand = append(cliCommand, "--username", username, "--password", password)
-	}
-
-	return cliCommand
+// connectionConfig is the configuration for the nrjmx command.
+type connectionConfig struct {
+	hostname           string
+	port               string
+	username           string
+	password           string
+	keyStore           string
+	keyStorePassword   string
+	trustStore         string
+	trustStorePassword string
+	remote             bool
 }
 
-func getCommandWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string) []string {
-	var cliCommand []string
-
-	if os.Getenv("NR_JMX_TOOL") != "" {
-		cliCommand = strings.Split(os.Getenv("NR_JMX_TOOL"), " ")
-	} else {
-		cliCommand = []string{jmxCommand}
-	}
-
-	cliCommand = append(cliCommand, "--hostname", hostname, "--port", port)
-	if username != "" && password != "" {
-		cliCommand = append(cliCommand, "--username", username, "--password", password)
-	}
-
-	if keyStore != "" && keyStorePassword != "" && trustStore != "" && trustStorePassword != "" {
-		cliCommand = append(cliCommand, "--keyStore", keyStore, "--keyStorePassword", keyStorePassword, "--trustStore", trustStore, "--trustStorePassword", trustStorePassword)
-	}
-
-	return cliCommand
+func (cfg *connectionConfig) isSSL() bool {
+	return cfg.keyStore != "" && cfg.keyStorePassword != "" && cfg.trustStore != "" && cfg.trustStorePassword != ""
 }
 
-// Open will start the nrjmx command with the provided connection parameters.
-func Open(hostname, port, username, password string) error {
+func (cfg *connectionConfig) command() []string {
+	c := make([]string, 0)
+	if os.Getenv("NR_JMX_TOOL") != "" {
+		c = strings.Split(os.Getenv("NR_JMX_TOOL"), " ")
+	} else {
+		c = []string{jmxCommand}
+	}
+
+	c = append(c, "--hostname", cfg.hostname, "--port", cfg.port)
+	if cfg.username != "" && cfg.password != "" {
+		c = append(c, "--username", cfg.username, "--password", cfg.password)
+	}
+	if cfg.remote {
+		c = append(c, "--remote")
+	}
+	if cfg.isSSL() {
+		c = append(c, "--keyStore", cfg.keyStore, "--keyStorePassword", cfg.keyStorePassword, "--trustStore", cfg.trustStore, "--trustStorePassword", cfg.trustStorePassword)
+	}
+
+	return c
+}
+
+// Open executes a nrjmx command using the given options.
+func Open(hostname, port, username, password string, opts ...Option) error {
+	config := &connectionConfig{
+		hostname: hostname,
+		port:     port,
+		username: username,
+		password: password,
+	}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	return openConnection(config)
+}
+
+// Option sets an option on integration level.
+type Option func(config *connectionConfig)
+
+// WithSSL for SSL connection configuration.
+func WithSSL(keyStore, keyStorePassword, trustStore, trustStorePassword string) Option {
+	return func(config *connectionConfig) {
+		config.keyStore = keyStore
+		config.keyStorePassword = keyStorePassword
+		config.trustStore = trustStore
+		config.trustStorePassword = trustStorePassword
+	}
+}
+
+// WithRemoteProtocol uses the remote JMX protocol URL.
+func WithRemoteProtocol() Option {
+	return func(config *connectionConfig) {
+		config.remote = true
+	}
+}
+
+func openConnection(config *connectionConfig) error {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -96,62 +132,7 @@ func Open(hostname, port, username, password string) error {
 	var err error
 	var ctx context.Context
 
-	cliCommand := getCommand(hostname, port, username, password)
-
-	ctx, cancel = context.WithCancel(context.Background())
-	cmd = exec.CommandContext(ctx, cliCommand[0], cliCommand[1:]...)
-
-	if cmdOut, err = cmd.StdoutPipe(); err != nil {
-		return err
-	}
-	if cmdIn, err = cmd.StdinPipe(); err != nil {
-		return err
-	}
-
-	if cmdError, err = cmd.StderrPipe(); err != nil {
-		return err
-	}
-
-	if err = cmd.Start(); err != nil {
-		return err
-	}
-
-	go func() {
-		if err = cmd.Wait(); err != nil {
-			stdErr, _ := ioutil.ReadAll(cmdError)
-			cmdErr <- fmt.Errorf("JMX tool exited with error: %s [state: %s] (%s)", err, cmd.ProcessState, string(stdErr))
-		}
-
-		lock.Lock()
-		defer lock.Unlock()
-		cmd = nil
-
-		done.Done()
-	}()
-
-	return nil
-}
-
-// OpenWithSSL will start the nrjmx command with the provided SSL connection parameters
-func OpenWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword string) error {
-	lock.Lock()
-	defer lock.Unlock()
-
-	if cmd != nil {
-		return ErrJmxCmdRunning
-	}
-
-	// Drain error channel to prevent showing past errors
-	if len(cmdErr) > 0 {
-		<-cmdErr
-	}
-
-	done.Add(1)
-
-	var err error
-	var ctx context.Context
-
-	cliCommand := getCommandWithSSL(hostname, port, username, password, keyStore, keyStorePassword, trustStore, trustStorePassword)
+	cliCommand := config.command()
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cmd = exec.CommandContext(ctx, cliCommand[0], cliCommand[1:]...)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -35,50 +35,66 @@
 		{
 			"checksumSHA1": "ZfId5ZYn7jmL0xTxooHcxrLlXoA=",
 			"path": "github.com/newrelic/infra-integrations-sdk/args",
-			"revision": "8edd0e042cfbb581c2386d3ed26b0cc5ecdd433b",
-			"revisionTime": "2019-02-11T14:59:35Z"
+			"revision": "def6661fb2892b29a94972e68b8d9b14f73f2542",
+			"revisionTime": "2019-03-18T15:14:23Z",
+			"version": "v3.1.3",
+			"versionExact": "v3.1.3"
 		},
 		{
 			"checksumSHA1": "KaZLSd/JUZz/mqfW3jFd1j2QdWA=",
 			"path": "github.com/newrelic/infra-integrations-sdk/data/event",
-			"revision": "8edd0e042cfbb581c2386d3ed26b0cc5ecdd433b",
-			"revisionTime": "2019-02-11T14:59:35Z"
+			"revision": "def6661fb2892b29a94972e68b8d9b14f73f2542",
+			"revisionTime": "2019-03-18T15:14:23Z",
+			"version": "v3.1.3",
+			"versionExact": "v3.1.3"
 		},
 		{
 			"checksumSHA1": "EOoxXGqFDPkCvj7wec2S5kCXY2I=",
 			"path": "github.com/newrelic/infra-integrations-sdk/data/inventory",
-			"revision": "8edd0e042cfbb581c2386d3ed26b0cc5ecdd433b",
-			"revisionTime": "2019-02-11T14:59:35Z"
+			"revision": "def6661fb2892b29a94972e68b8d9b14f73f2542",
+			"revisionTime": "2019-03-18T15:14:23Z",
+			"version": "v3.1.3",
+			"versionExact": "v3.1.3"
 		},
 		{
 			"checksumSHA1": "39SDqHpLpE9J1nrIwYI+8ukzXJs=",
 			"path": "github.com/newrelic/infra-integrations-sdk/data/metric",
-			"revision": "8edd0e042cfbb581c2386d3ed26b0cc5ecdd433b",
-			"revisionTime": "2019-02-11T14:59:35Z"
+			"revision": "def6661fb2892b29a94972e68b8d9b14f73f2542",
+			"revisionTime": "2019-03-18T15:14:23Z",
+			"version": "v3.1.3",
+			"versionExact": "v3.1.3"
 		},
 		{
-			"checksumSHA1": "Q23NjXVh6j31N6ZChLG/FNv7fwU=",
+			"checksumSHA1": "Roed3yHqlmKnpp8gDhw8Pgh+oW8=",
 			"path": "github.com/newrelic/infra-integrations-sdk/integration",
-			"revision": "8edd0e042cfbb581c2386d3ed26b0cc5ecdd433b",
-			"revisionTime": "2019-02-11T14:59:35Z"
+			"revision": "def6661fb2892b29a94972e68b8d9b14f73f2542",
+			"revisionTime": "2019-03-18T15:14:23Z",
+			"version": "v3.1.3",
+			"versionExact": "v3.1.3"
 		},
 		{
-			"checksumSHA1": "wanhzjt9MSS/rT2YpZIWkVjwpOM=",
+			"checksumSHA1": "yqj7MwhatN5UNdMaCrfjemYhGMw=",
 			"path": "github.com/newrelic/infra-integrations-sdk/jmx",
-			"revision": "8edd0e042cfbb581c2386d3ed26b0cc5ecdd433b",
-			"revisionTime": "2019-02-11T14:59:35Z"
+			"revision": "def6661fb2892b29a94972e68b8d9b14f73f2542",
+			"revisionTime": "2019-03-18T15:14:23Z",
+			"version": "v3.1.3",
+			"versionExact": "v3.1.3"
 		},
 		{
 			"checksumSHA1": "6/DhD+/LhC/k3NaLgkpd6iE8b5E=",
 			"path": "github.com/newrelic/infra-integrations-sdk/log",
-			"revision": "8edd0e042cfbb581c2386d3ed26b0cc5ecdd433b",
-			"revisionTime": "2019-02-11T14:59:35Z"
+			"revision": "def6661fb2892b29a94972e68b8d9b14f73f2542",
+			"revisionTime": "2019-03-18T15:14:23Z",
+			"version": "v3.1.3",
+			"versionExact": "v3.1.3"
 		},
 		{
 			"checksumSHA1": "BsHp62Etporko0d+4GpVxrP2qtw=",
 			"path": "github.com/newrelic/infra-integrations-sdk/persist",
-			"revision": "8edd0e042cfbb581c2386d3ed26b0cc5ecdd433b",
-			"revisionTime": "2019-02-11T14:59:35Z"
+			"revision": "def6661fb2892b29a94972e68b8d9b14f73f2542",
+			"revisionTime": "2019-03-18T15:14:23Z",
+			"version": "v3.1.3",
+			"versionExact": "v3.1.3"
 		},
 		{
 			"checksumSHA1": "0H/VjT8w1CB702qWpbYMqr65Mf0=",


### PR DESCRIPTION
**Context**:
JBoss 6.4 uses remoting protocol which is not compatible with current JMX Integration

**Added**: Added a new remote flag for using the remote JMX protocol URL.
**Changed**: Updated SDK with the new remote JMX protocol flag

#### PR Review Checklist
- [ ] TODO: update vendor with the SDK changes: https://github.com/newrelic/infra-integrations-sdk/pull/175 

### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
