### PR TITLE
Bean patter error displays correct pattern

### DIFF
--- a/src/request.go
+++ b/src/request.go
@@ -33,7 +33,7 @@ func runCollection(collection []*domainDefinition, i *integration.Integration, h
 			result, err := jmxQueryFunc(requestString, args.Timeout)
 			if err != nil {
 				if err == jmx.ErrBeanPattern {
-					return fmt.Errorf("cannot parse bean pattern: %s", requestString)
+					return fmt.Errorf("%s, your pattern: %s", err, requestString)
 				}
 				return fmt.Errorf("cannot query: %s, error: %s", requestString, err.Error())
 			}


### PR DESCRIPTION
#### Description of the changes

An MBean pattern error now displays the correct pattern.

Msg displayed before:

```
[ERR] Failed to complete collection: cannot parse bean pattern: *:
```

Msg displayed now:

```
[ERR] Failed to complete collection: cannot parse MBean glob pattern, valid: 'DOMAIN:BEAN', your pattern: *:
```

#### PR Review Checklist
### Author

- [ ] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
