### PR TITLE
An empty JMX result no longer stops processing the remaining queries

### DIFF
--- a/src/request.go
+++ b/src/request.go
@@ -39,7 +39,8 @@ func runCollection(collection []*domainDefinition, i *integration.Integration, h
 			}
 
 			if len(result) == 0 {
-				return fmt.Errorf("empty data for pattern: %s", requestString)
+				handlingErrs = append(handlingErrs, fmt.Errorf("empty data for pattern: %s", requestString))
+				continue
 			}
 
 			if err := handleResponse(domain.eventType, request, result, i, host, port); err != nil {


### PR DESCRIPTION
#### Description of the changes

Currently if a JMX query returns an empty response, the logic stops processing the remaining queries. It's common for some applications to dynamically create mbeans as needed and in some situations there may not be instances of those mbeans in one instance of the application, but may exist in others. This change allows the situation to be logged but doesn't stop processing the remaining JMX queries.

#### PR Review Checklist
### Author

- [ ] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
