### PR TITLE
fix: upgrade jmx from SDK with a fix for warnings

### DIFF
--- a/vendor/github.com/newrelic/infra-integrations-sdk/LICENSE
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/LICENSE
@@ -1,21 +1,47 @@
-MIT License
+All components of this product are Copyright (c) 2017 New Relic, Inc.  All
+rights reserved.
 
-Copyright (c) 2019 New Relic
+Certain inventions disclosed in this file may be claimed within patents owned or
+patent applications filed by New Relic, Inc. or third parties.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Subject to the terms of this notice, New Relic grants you a nonexclusive,
+nontransferable license, without the right to sublicense, to (a) install and
+execute one copy of these files on any number of workstations owned or
+controlled by you and (b) distribute verbatim copies of these files to third
+parties.  You may install, execute, and distribute these files and their
+contents only in conjunction with your direct use of New Relic’s services.
+These files and their contents shall not be used with or to develop any other
+product or software that may compete with any New Relic product, feature, or
+software. As a condition to the foregoing grant, you must provide this notice
+along with each copy you distribute and you must not remove, alter, or obscure
+this notice.  In the event you submit or provide any feedback, code, pull
+requests, or suggestions to New Relic you hereby grant New Relic a worldwide,
+non-exclusive, irrevocable, transferable, fully paid-up license to use the code,
+algorithms, patents, and ideas therein in our products.  In addition to the
+rights above, New Relic grants a limited right to you to modify this product as
+necessary to enable interoperability with other systems, provided that (a) such
+use is solely to enable your direct use of New Relic services and (b) you agree
+to make any such modifications available to New Relic in a pull request or as
+separate feedback.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+All other use, reproduction, modification, distribution, or other exploitation
+of these files is strictly prohibited, except as may be set forth in a separate
+written license agreement between you and New Relic.  The terms of any such
+license agreement will control over this notice.  The license stated above will
+be automatically terminated and revoked if you exceed its scope or violate any
+of the terms of this notice.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of New Relic, except as required for reasonable
+and customary use in describing the origin of this file and reproducing the
+content of this notice.  You may not mark or brand this file with any trade
+name, trademarks, service marks, or product names other than the original brand
+(if any) provided by New Relic.
+
+Unless otherwise expressly agreed by New Relic in a separate written license
+agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND,
+including without any implied warranties of MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a condition to your use of
+these files, you are solely responsible for such use. New Relic will have no
+liability to you for direct, indirect, consequential, incidental, special, or
+punitive damages or for lost profits or data.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -73,12 +73,12 @@
 			"versionExact": "v3.3.1"
 		},
 		{
-			"checksumSHA1": "Cz0x0qEmD9hIDSBaBVRQI4EUxwM=",
+			"checksumSHA1": "ZnX7aXbVkTjqHg0eSpVMEl672Q0=",
 			"path": "github.com/newrelic/infra-integrations-sdk/jmx",
-			"revision": "33232b0615c59f50fdd2a756dc07f730b36150d8",
-			"revisionTime": "2019-11-19T18:59:22Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "e4dedaa80697a813f14e2eda8e2a6f13732e7174",
+			"revisionTime": "2021-01-11T17:03:17Z",
+			"version": "fix/v331-warning-stops-mbeans-processing",
+			"versionExact": "fix/v331-warning-stops-mbeans-processing"
 		},
 		{
 			"checksumSHA1": "6/DhD+/LhC/k3NaLgkpd6iE8b5E=",


### PR DESCRIPTION
Upgrades JMX package from SDK branch `fix/v331-warning-stops-mbeans-processing` to fix issue when warnings in NRJMX discards integration output