### PR TITLE
ci: dynamic repo access_point_host for pre/release pipelines

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -195,6 +195,7 @@ jobs:
           tag: ${{env.TAG}}
           app_name: "nri-${{env.INTEGRATION}}"
           repo_name: ${{ env.ORIGINAL_REPO_NAME }}
+          access_point_host: "staging"
           schema: "ohi-jmx" # ohi-jmx for integrations that bundle JMX on windows installers
           aws_region: "us-east-1"
           aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
           tag: ${{env.TAG}}
           app_name: "nri-${{env.INTEGRATION}}"
           repo_name: ${{ env.ORIGINAL_REPO_NAME }}
+          access_point_host: "production"
           # 'ohi' is for integrations
           schema: "ohi-jmx" # ohi-jmx for integrations that bundle JMX on windows installers
           aws_region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
Added `access_point_host` variable to release/prerelease pipelines in order to use different repositories in production and staging.
