### PR TITLE
fix: removed wrong tag for definition file

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -57,7 +57,6 @@ nfpms:
         dst: "/usr/share/doc/nri-jmx/LICENSE"
       - src: "jmx-definition.yml"
         dst: "/var/db/newrelic-infra/newrelic-integrations/jmx-definition.yml"
-        type: config
 
     overrides:
       deb:


### PR DESCRIPTION
This PR fixes the issue when nri-jmx doesn't contain the definition file