### PR TITLE
chore: upgraded github.com/newrelic/infra-integrations-sdk to v3.6.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/golangci/golangci-lint v1.39.0
 	github.com/kr/pretty v0.2.1
-	github.com/newrelic/infra-integrations-sdk v3.6.7+incompatible
+	github.com/newrelic/infra-integrations-sdk v3.6.9+incompatible
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -446,6 +446,10 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6Fx
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/newrelic/infra-integrations-sdk v3.6.7+incompatible h1:dOsTM3DT6piFLpWLroIFw1Yy5ZqHpnS0HoS6B6WOV7k=
 github.com/newrelic/infra-integrations-sdk v3.6.7+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
+github.com/newrelic/infra-integrations-sdk v3.6.8+incompatible h1:EBFBmBxNXpsTbDb5qpMC9QahgQrBWc+El+1JqwQVk24=
+github.com/newrelic/infra-integrations-sdk v3.6.8+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
+github.com/newrelic/infra-integrations-sdk v3.6.9+incompatible h1:5YTvG74STGz1gq+gw08UDDMAP1bWmtMuyUgdBS4C/vU=
+github.com/newrelic/infra-integrations-sdk v3.6.9+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0 h1:kVlMw8h2LHPMGUVqUj6230oQjjTMFjwcZrnkhXzFfl8=


### PR DESCRIPTION
This version of the sdk, in case of any error parsing the nrjmx output, will add the "problematic output" to the error and the agent will log it.