### PR TITLE
NR-42319 JMX improvements

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,7 +10,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GO_VERSION: '1.18'
-  NRJMX_VERSION: '2.0.2'
+  NRJMX_VERSION: '2.2.2'
   INTEGRATION: "jmx"
   ORIGINAL_REPO_NAME: 'newrelic/nri-jmx'
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -12,7 +12,7 @@ env:
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}
   ORIGINAL_REPO_NAME: "newrelic/nri-jmx"
   GO_VERSION: '1.18'
-  NRJMX_VERSION: '2.0.2'
+  NRJMX_VERSION: '2.2.2'
   DOCKER_LOGIN_AVAILABLE: ${{ secrets.OHAI_DOCKER_HUB_ID }}
 
 jobs:

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -66,14 +66,14 @@ nfpms:
       deb:
         dependencies:
           - newrelic-infra (>= 1.20.0)
-          - nrjmx (>= 2.0.2)
+          - nrjmx (>= 2.2.2)
       rpm:
         file_name_template: "{{ .ProjectName }}-{{ .Version }}-1.{{ .Arch }}"
         replacements:
           amd64: x86_64
         dependencies:
           - newrelic-infra (>= 1.20.0)
-          - nrjmx >= 2.0.2
+          - nrjmx >= 2.2.2
 
     # Formats to be generated.
     formats:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golangci/golangci-lint v1.43.0
 	github.com/kr/pretty v0.2.1
 	github.com/newrelic/infra-integrations-sdk v3.7.0+incompatible
-	github.com/newrelic/nrjmx/gojmx v0.0.0-20220805091631-f89f03942044
+	github.com/newrelic/nrjmx/gojmx v0.0.0-20220831103627-56d00601006c
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -801,6 +801,8 @@ github.com/newrelic/nrjmx/gojmx v0.0.0-20220524090039-95055adfdbad h1:7ucIlQXlsg
 github.com/newrelic/nrjmx/gojmx v0.0.0-20220524090039-95055adfdbad/go.mod h1:VAIxyJGOLEWTVmblrHG8fWey4qF6lNQgTkS9qBJ4HGk=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20220805091631-f89f03942044 h1:/K+yOh6PPSXCUXAzSTgS9pmMreWtFMnFjvjqHqKtxeM=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20220805091631-f89f03942044/go.mod h1:zd01rBtry4cfiVBXpUhBeEjolk86vMczWd/d7QQHGK8=
+github.com/newrelic/nrjmx/gojmx v0.0.0-20220831103627-56d00601006c h1:B6Fj3lqF+NnztRe+DMXRJsp+gKRKhznmQd5qzQAEP/U=
+github.com/newrelic/nrjmx/gojmx v0.0.0-20220831103627-56d00601006c/go.mod h1:zd01rBtry4cfiVBXpUhBeEjolk86vMczWd/d7QQHGK8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.2.3 h1:+ANTMqRNrqwInnP9aszg/0jDo+zbXa4x66U19Bx/oTk=

--- a/src/collect.go
+++ b/src/collect.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package main
 
 import (

--- a/src/collect_test.go
+++ b/src/collect_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package main
 
 import (

--- a/src/collect_test.go
+++ b/src/collect_test.go
@@ -26,7 +26,7 @@ func (j *jmxClientMock) Close() error {
 	return j.err
 }
 
-func (j *jmxClientMock) QueryMBeanAttributes(mBeanNamePattern string) ([]*gojmx.AttributeResponse, error) {
+func (j *jmxClientMock) QueryMBeanAttributes(mBeanNamePattern string, mBeanAttributeName ...string) ([]*gojmx.AttributeResponse, error) {
 	return j.response, j.err
 }
 

--- a/src/config_parse.go
+++ b/src/config_parse.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package main
 
 import (

--- a/src/config_parse_test.go
+++ b/src/config_parse_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package main
 
 import (

--- a/src/connection.go
+++ b/src/connection.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package main
 
 import (

--- a/src/connection.go
+++ b/src/connection.go
@@ -15,5 +15,5 @@ var (
 type Client interface {
 	Open(config *gojmx.JMXConfig) (*gojmx.Client, error)
 	Close() error
-	QueryMBeanAttributes(mBeanNamePattern string) ([]*gojmx.AttributeResponse, error)
+	QueryMBeanAttributes(mBeanNamePattern string, mBeanAttributeName ...string) ([]*gojmx.AttributeResponse, error)
 }

--- a/src/format.go
+++ b/src/format.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package main
 
 import (

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -119,7 +119,7 @@ func main() {
 	}
 
 	defer func() {
-		if err := jmxClient.Close(); err != nil {
+		if err = jmxClient.Close(); err != nil {
 			log.Error(
 				"Failed to close JMX connection: %s", err)
 		}
@@ -128,6 +128,7 @@ func main() {
 	err = runMetricCollection(jmxIntegration, jmxClient)
 	if err != nil {
 		log.Fatal(err)
+		return
 	}
 
 	jmxIntegration.Entities = checkMetricLimit(jmxIntegration.Entities)

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -69,20 +69,14 @@ var (
 func main() {
 	// Create a new integration
 	jmxIntegration, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
-	if err != nil {
-		log.Fatal(err)
-		return
-	}
+	fatalIfErr(err)
 
 	jmxClient := gojmx.NewClient(context.Background())
 
 	// Troubleshooting mode, we need to read the args from the configuration file.
 	if args.Query != "" {
 		err = SetArgs(args.InstanceName, args.ConfigFile)
-		if err != nil {
-			log.Fatal(err)
-			return
-		}
+		fatalIfErr(err)
 
 		result := FormatQuery(jmxClient, getJMXConfig(), args.Query, args.HideSecrets)
 		fmt.Println(result)
@@ -126,10 +120,7 @@ func main() {
 	}()
 
 	err = runMetricCollection(jmxIntegration, jmxClient)
-	if err != nil {
-		log.Fatal(err)
-		return
-	}
+	fatalIfErr(err)
 
 	jmxIntegration.Entities = checkMetricLimit(jmxIntegration.Entities)
 
@@ -357,4 +348,10 @@ func getJMXConfig() *gojmx.JMXConfig {
 		jmxConfig.UriPath = &(args.JmxURIPath)
 	}
 	return jmxConfig
+}
+
+func fatalIfErr(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -112,14 +112,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	defer func() {
-		if err = jmxClient.Close(); err != nil {
-			log.Error(
-				"Failed to close JMX connection: %s", err)
-		}
-	}()
-
 	err = runMetricCollection(jmxIntegration, jmxClient)
+
+	// Make sure we close the connection after collection was done.
+	// We cannot defer this, since we are using log.Fail/os.Exit
+	if connErr := jmxClient.Close(); connErr != nil {
+		log.Error(
+			"Failed to close JMX connection: %s", err)
+	}
+
 	fatalIfErr(err)
 
 	jmxIntegration.Entities = checkMetricLimit(jmxIntegration.Entities)

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -1,4 +1,9 @@
 //go:generate goversioninfo
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package main
 
 import (

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -3,12 +3,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/newrelic/nrjmx/gojmx"
 
@@ -49,6 +51,10 @@ type argumentList struct {
 	JmxURIPath               string `default:"" help:"The path portion of the JMX Service URI. This is useful for nonstandard service uris"`
 	JmxUser                  string `default:"" help:"The username for the JMX connection"`
 	JmxPass                  string `default:"" help:"The password for the JMX connection"`
+	LongRunning              bool   `default:"false" help:"BETA: In long-running mode integration process will be kept alive"`
+	HeartbeatInterval        int    `default:"5" help:"BETA: Interval in seconds for submitting the heartbeat while in long-running mode"`
+	Interval                 int    `default:"30" help:"BETA: Interval in seconds for collecting data while while in long-running mode"`
+	EnableInternalStats      bool   `default:"false" help:"Print nrjmx internal query stats for troubleshooting"`
 }
 
 var (
@@ -56,6 +62,8 @@ var (
 	integrationVersion = "0.0.0"
 	gitCommit          = ""
 	buildDate          = ""
+
+	errNRJMXNotRunning = errors.New("nrjmx client sub-process not running")
 )
 
 func main() {
@@ -95,31 +103,31 @@ func main() {
 
 	log.SetupLogging(args.Verbose)
 
-	jmxConfig := getJMXConfig()
-
-	_, err = jmxClient.Open(jmxConfig)
-	log.Debug("nrjmx version: %s", jmxClient.GetClientVersion())
-
-	if err != nil {
-		log.Error("Failed to open JMX connection, error: %v, Config: (%s)",
-			err,
-			gojmx.FormatConfig(jmxConfig, args.HideSecrets),
-		)
-		os.Exit(1)
-	}
-
 	// Ensure a collection file is specified
 	if args.CollectionFiles == "" && args.CollectionConfig == "" {
 		log.Error("Must specify at least one collection file or a collection config JSON")
 		os.Exit(1)
 	}
 
-	runCollectionFiles(jmxIntegration, jmxClient)
-	runCollectionConfig(jmxIntegration, jmxClient)
+	jmxClient, err = openJMXConnection()
+	if err != nil {
+		log.Error("Failed to open JMX connection, error: %v, Config: (%s)",
+			err,
+			gojmx.FormatConfig(getJMXConfig(), args.HideSecrets),
+		)
+		os.Exit(1)
+	}
 
-	if err := jmxClient.Close(); err != nil {
-		log.Error(
-			"Failed to close JMX connection: %s", err)
+	defer func() {
+		if err := jmxClient.Close(); err != nil {
+			log.Error(
+				"Failed to close JMX connection: %s", err)
+		}
+	}()
+
+	err = runMetricCollection(jmxIntegration, jmxClient)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	jmxIntegration.Entities = checkMetricLimit(jmxIntegration.Entities)
@@ -211,6 +219,117 @@ func checkMetricLimit(entities []*integration.Entity) []*integration.Entity {
 	return validEntities
 }
 
+// runMetricCollection will perform the metrics collection.
+func runMetricCollection(i *integration.Integration, jmxClient *gojmx.Client) error {
+	if args.LongRunning {
+		return collectMetricsEachInterval(i, jmxClient)
+	}
+	return collectMetrics(i, jmxClient)
+}
+
+// collectMetricsEachInterval will collect the metrics periodically when configured in long-running mode.
+func collectMetricsEachInterval(i *integration.Integration, jmxClient *gojmx.Client) error {
+	metricInterval := time.NewTicker(time.Duration(args.Interval) * time.Second)
+
+	runHeartBeat()
+
+	// do ... while.
+	for ; true; <-metricInterval.C {
+		// Check if the nrjmx java sub-process is still alive.
+		if !jmxClient.IsRunning() {
+			return errNRJMXNotRunning
+		}
+
+		if err := collectMetrics(i, jmxClient); err != nil {
+			log.Error("Failed to collect metrics, error: %v", err)
+			continue
+		}
+
+		if err := i.Publish(); err != nil {
+			log.Error("Failed to publish metrics, error: %v", err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// collectMetrics will gather all the required metrics from the JMX endpoint and attach them the the sdk integration.
+func collectMetrics(i *integration.Integration, jmxClient *gojmx.Client) error {
+	// For troubleshooting purpose, if enabled, integration will log internal query stats.
+	if args.EnableInternalStats {
+		defer func() {
+			logInternalStats(jmxClient)
+		}()
+	}
+
+	runCollectionFiles(i, jmxClient)
+	runCollectionConfig(i, jmxClient)
+
+	return nil
+}
+
+// runHeartBeat is used in long-running mode to signal to the agent that the integration is alive.
+func runHeartBeat() {
+	heartBeat := time.NewTicker(time.Duration(args.HeartbeatInterval) * time.Second)
+
+	go func() {
+		for range heartBeat.C {
+			log.Debug("Sending heartBeat")
+			// heartbeat signal for long-running integrations
+			// https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/host-integrations-newer-configuration-format#timeout
+			fmt.Println("{}")
+		}
+	}()
+}
+
+// logInternalStats will print in verbose logs statistics gathered by nrjmx client
+// that can be handy when troubleshooting performance issues.
+func logInternalStats(jmxClient *gojmx.Client) {
+	internalStats, err := jmxClient.GetInternalStats()
+	if err != nil {
+		log.Error("Failed to collect nrjmx internal stats, %v", err)
+		return
+	}
+
+	for _, stat := range internalStats {
+		log.Debug("%v", stat)
+	}
+
+	// Aggregated stats.
+	log.Debug("%v", internalStats)
+}
+
+// openJMXConnection configures the JMX client and attempts to connect to the endpoint.
+func openJMXConnection() (*gojmx.Client, error) {
+	jmxConfig := getJMXConfig()
+
+	hideSecrets := true
+	formattedConfig := gojmx.FormatConfig(jmxConfig, hideSecrets)
+
+	jmxClient := gojmx.NewClient(context.Background())
+	_, err := jmxClient.Open(jmxConfig)
+
+	log.Debug("nrjmx version: %s, config: %s", jmxClient.GetClientVersion(), formattedConfig)
+
+	if err != nil {
+		// When not in long-running mode, we cannot recover from any type of connection error.
+		// However, in long-running mode, we can recover later from errors related with connection, except JMXClient error
+		// which means that the nrjmx java sub-process was closed.
+		if _, ok := gojmx.IsJMXClientError(err); ok || !args.LongRunning {
+			return nil, fmt.Errorf("failed to open JMX connection, error: %w, Config: (%s)",
+				err,
+				formattedConfig,
+			)
+		}
+
+		// In long-running mode just log the error.
+		log.Error("Error while connecting to jmx connection, err: %v", err)
+	}
+
+	return jmxClient, nil
+}
+
 func getJMXConfig() *gojmx.JMXConfig {
 	port, err := strconv.ParseInt(args.JmxPort, 10, 32) //nolint
 	if err != nil {
@@ -231,6 +350,7 @@ func getJMXConfig() *gojmx.JMXConfig {
 		RequestTimeoutMs:      int64(args.Timeout),
 		UseSSL:                args.JmxSSL,
 		Verbose:               args.Verbose,
+		EnableInternalStats:   args.EnableInternalStats,
 	}
 	if args.JmxURIPath != "" {
 		jmxConfig.UriPath = &(args.JmxURIPath)

--- a/src/jmx_test.go
+++ b/src/jmx_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package main
 
 import (

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -10,6 +10,8 @@ services:
         -Dcom.sun.management.jmxremote.port=9999
         -Dcom.sun.management.jmxremote.rmi.port=9999
         -Djava.rmi.server.hostname=tomcat
+    ports:
+    - "9999:9999"
 
   nri-jmx:
     container_name: integration_nri-jmx_1

--- a/test/integration/helpers/helpers.go
+++ b/test/integration/helpers/helpers.go
@@ -1,3 +1,11 @@
+//go:build integration
+// +build integration
+
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package helpers
 
 import (
@@ -5,14 +13,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/newrelic/infra-integrations-sdk/log"
-	"github.com/newrelic/nri-jmx/test/integration/jsonschema"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/newrelic/nri-jmx/test/integration/jsonschema"
+	"github.com/stretchr/testify/assert"
 )
 
 // ExecInContainer executes the given command inside the specified container. It returns three values:

--- a/test/integration/helpers/helpers.go
+++ b/test/integration/helpers/helpers.go
@@ -1,10 +1,18 @@
 package helpers
 
 import (
+	"bufio"
 	"bytes"
+	"context"
+	"fmt"
 	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/newrelic/nri-jmx/test/integration/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"io"
 	"os/exec"
 	"strings"
+	"testing"
+	"time"
 )
 
 // ExecInContainer executes the given command inside the specified container. It returns three values:
@@ -35,4 +43,194 @@ func ExecInContainer(container string, command []string, envVars ...string) (str
 	stderr := errbuf.String()
 
 	return stdout, stderr, err
+}
+
+// NewDockerExecCommand returns a configured un-started exec.Cmd for a docker exec command.
+func NewDockerExecCommand(ctx context.Context, t *testing.T, containerName string, args []string, envVars map[string]string) *exec.Cmd {
+	cmdLine := []string{
+		"exec",
+		"-i",
+	}
+
+	for key, val := range envVars {
+		cmdLine = append(cmdLine, "-e", fmt.Sprintf("%s=%s", key, val))
+	}
+
+	cmdLine = append(cmdLine, containerName)
+	cmdLine = append(cmdLine, args...)
+
+	t.Logf("executing: docker %s", strings.Join(cmdLine, " "))
+
+	return exec.CommandContext(ctx, "docker", cmdLine...)
+}
+
+// Output for a long-running docker exec command.
+type Output struct {
+	StdoutCh chan string
+	StderrCh chan string
+}
+
+// NewOutput returns a new Output object.
+func NewOutput() *Output {
+	size := 1000
+	return &Output{
+		StdoutCh: make(chan string, size),
+		StderrCh: make(chan string, size),
+	}
+}
+
+// Flush will empty the Output channels and returns the content.
+func (o *Output) Flush(t *testing.T) (stdout []string, stderr []string) {
+	for {
+		select {
+		case line := <-o.StdoutCh:
+			t.Logf("Flushing stdout line: %s", line)
+			stdout = append(stdout, line)
+		case line := <-o.StderrCh:
+			t.Logf("Flushing stderr line: %s", line)
+			stderr = append(stderr, line)
+		default:
+			return
+		}
+	}
+}
+
+// StartLongRunningProcess will execute a command and will pipe the stdout & stderr into and Output object.
+func StartLongRunningProcess(ctx context.Context, t *testing.T, cmd *exec.Cmd) (*Output, error) {
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	copyToChan := func(ctx context.Context, reader io.Reader, outputC chan string) {
+		scanner := bufio.NewScanner(reader)
+		for scanner.Scan() && ctx.Err() == nil {
+			outputC <- scanner.Text()
+		}
+
+		if err := scanner.Err(); ctx.Err() == nil && err != nil {
+			t.Logf("Error while reading the pipe, %v", err)
+			return
+		}
+
+		t.Log("Finished reading the pipe")
+	}
+
+	output := NewOutput()
+
+	go copyToChan(ctx, stdout, output.StdoutCh)
+	go copyToChan(ctx, stderr, output.StderrCh)
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+// RunDockerCommandForContainer will execute a docker command for the specified containerName.
+func RunDockerCommandForContainer(t *testing.T, command, containerName string) error {
+	t.Logf("running docker %s container %s", command, containerName)
+
+	cmd := exec.Command("docker", command, containerName)
+
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("errror while %s the container '%s', error: %v, stderr: %s", command, containerName, err, errBuf.String())
+	}
+
+	return nil
+}
+
+// AssertReceivedErrors check if at least one the log lines provided contains the given message.
+func AssertReceivedErrors(t *testing.T, msg string, errLog ...string) {
+	assert.GreaterOrEqual(t, len(errLog), 1)
+
+	for _, line := range errLog {
+		if strings.Contains(line, msg) {
+			return
+		}
+	}
+
+	assert.Failf(t, fmt.Sprintf("Expected to find the following error message: %s", msg), "but got %s", errLog)
+}
+
+// AssertReceivedPayloadsMatchSchema will check if payloads inside Output object matches the give JSON schema.
+func AssertReceivedPayloadsMatchSchema(t *testing.T, ctx context.Context, output *Output, schemaPath string, timeout time.Duration) {
+	var cancelFn context.CancelFunc
+
+	ctx, cancelFn = context.WithTimeout(ctx, timeout)
+	defer cancelFn()
+
+	validPayloads := 0
+	validHeartbeats := 0
+
+	for {
+		if validPayloads >= 3 && validHeartbeats >= 3 {
+			break
+		}
+
+		select {
+		case stdoutLine := <-output.StdoutCh:
+			if stdoutLine == "{}" {
+				t.Log("Received heartbeat")
+				validHeartbeats++
+			} else {
+				t.Logf("Received payload: %s", stdoutLine)
+
+				err := jsonschema.Validate(schemaPath, stdoutLine)
+				if err == nil {
+					validPayloads++
+				}
+				assert.NoError(t, err)
+			}
+
+		case stderrLine := <-output.StderrCh:
+			t.Logf("Received stderr: %s", stderrLine)
+
+			assert.Empty(t, FilterStderr(stderrLine))
+		case <-ctx.Done():
+			assert.FailNow(t, "didn't received output in time")
+		}
+	}
+}
+
+// FilterStderr is handy to filter some log lines that are expected.
+func FilterStderr(content string) string {
+	return FilterLines(content, ExpectedErrMessagesFilter)
+}
+
+func FilterLines(content string, filter func(line string) bool) string {
+	if content == "" {
+		return content
+	}
+	var result []string
+	for _, line := range strings.Split(content, "\n") {
+		if !filter(line) {
+			result = append(result, line)
+		}
+	}
+	return strings.Join(result, "\n")
+}
+
+func ExpectedErrMessagesFilter(line string) bool {
+	wordsToIgnoreLines := []string{
+		"[INFO]",
+		"[DEBUG]",
+		"non-numeric value for gauge metric",
+	}
+	for _, chunk := range wordsToIgnoreLines {
+		if strings.Contains(line, chunk) {
+			return true
+		}
+	}
+	return false
 }

--- a/test/integration/jmx_test.go
+++ b/test/integration/jmx_test.go
@@ -6,8 +6,12 @@ package integration
 import (
 	"context"
 	"flag"
+	"fmt"
+	"github.com/newrelic/nri-jmx/test/integration/jsonschema"
 	"github.com/stretchr/testify/require"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"

--- a/test/integration/jmx_test.go
+++ b/test/integration/jmx_test.go
@@ -228,13 +228,13 @@ func TestJMXIntegration_LongRunningIntegration(t *testing.T) {
 	// take time to timeout. The assumption is that after 60 seconds even if the jmx connection hangs,
 	// when we restart the container again it will fail because of a new server listening on jmx port.
 	log.Info("Waiting for jmx connection to fail")
-	time.Sleep(60 * time.Second)
+	time.Sleep(15 * time.Second)
 
 	err = helpers.RunDockerCommandForContainer(t, "start", serviceContainer)
 	require.NoError(t, err)
 
 	log.Info("Waiting for jmx server to be up again")
-	time.Sleep(30 * time.Second)
+	time.Sleep(15 * time.Second)
 
 	_, stderr := output.Flush(t)
 

--- a/test/integration/jmx_test.go
+++ b/test/integration/jmx_test.go
@@ -238,7 +238,7 @@ func TestJMXIntegration_LongRunningIntegration(t *testing.T) {
 
 	_, stderr := output.Flush(t)
 
-	helpers.AssertReceivedErrors(t, "connection error", stderr...)
+	helpers.AssertReceivedErrors(t, "JMX connection failed", stderr...)
 
 	helpers.AssertReceivedPayloadsMatchSchema(t, ctx, output, schemaFile, 10*time.Second)
 }

--- a/test/integration/jmx_test.go
+++ b/test/integration/jmx_test.go
@@ -1,6 +1,11 @@
 //go:build integration
 // +build integration
 
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package integration
 
 import (

--- a/test/integration/jmx_test.go
+++ b/test/integration/jmx_test.go
@@ -23,7 +23,9 @@ import (
 
 var (
 	defaultContainer = "integration_nri-jmx_1"
-	defaultBinPath   = "/nri-jmx"
+	serviceContainer = "integration_tomcat_1"
+
+	defaultBinPath = "/nri-jmx"
 
 	jmx_host               = "tomcat"
 	defaultCollectionFiles = "/jvm-metrics.yml,/tomcat-metrics.yml"
@@ -219,7 +221,7 @@ func TestJMXIntegration_LongRunningIntegration(t *testing.T) {
 	schemaFile := filepath.Join("json-schema-files", "jmx-schema.json")
 	helpers.AssertReceivedPayloadsMatchSchema(t, ctx, output, schemaFile, 10*time.Second)
 
-	err = helpers.RunDockerCommandForContainer(t, "stop", defaultContainer)
+	err = helpers.RunDockerCommandForContainer(t, "stop", serviceContainer)
 	require.NoError(t, err)
 
 	// Wait for the jmx connection to fail. We need to give it time as it might
@@ -228,7 +230,7 @@ func TestJMXIntegration_LongRunningIntegration(t *testing.T) {
 	log.Info("Waiting for jmx connection to fail")
 	time.Sleep(60 * time.Second)
 
-	err = helpers.RunDockerCommandForContainer(t, "start", defaultContainer)
+	err = helpers.RunDockerCommandForContainer(t, "start", serviceContainer)
 	require.NoError(t, err)
 
 	log.Info("Waiting for jmx server to be up again")

--- a/test/integration/jmx_test.go
+++ b/test/integration/jmx_test.go
@@ -228,13 +228,13 @@ func TestJMXIntegration_LongRunningIntegration(t *testing.T) {
 	// take time to timeout. The assumption is that after 60 seconds even if the jmx connection hangs,
 	// when we restart the container again it will fail because of a new server listening on jmx port.
 	log.Info("Waiting for jmx connection to fail")
-	time.Sleep(15 * time.Second)
+	time.Sleep(60 * time.Second)
 
 	err = helpers.RunDockerCommandForContainer(t, "start", serviceContainer)
 	require.NoError(t, err)
 
 	log.Info("Waiting for jmx server to be up again")
-	time.Sleep(15 * time.Second)
+	time.Sleep(30 * time.Second)
 
 	_, stderr := output.Flush(t)
 

--- a/test/integration/jsonschema/jsonschema.go
+++ b/test/integration/jsonschema/jsonschema.go
@@ -1,3 +1,11 @@
+//go:build integration
+// +build integration
+
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package jsonschema
 
 import (


### PR DESCRIPTION
### Changed
- Updated gojmx library to [v2.2.2](https://github.com/newrelic/nrjmx/releases/tag/v2.2.2)
- Optimisation of number of JMX queries by avoiding quering MBeans names when wildcard is not provided
### Added
- `ENABLE_INTERNAL_STATS` configuration option. When this option is enabled and the integration is running in verbose mode it will output in the logs nrjmx internal query statistics. This will be handy when troubleshooting performance issues.
- [BETA] Added long-running mode (`LONG_RUNNING` config option). When running in this mode the RMI connection will be reused instead of creating a new one every collection.