### PR TITLE
Added patch to GoLang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN git clone https://github.com/newrelic/nrjmx.git && \
     cd nrjmx && \
     mvn package -DskipTests -P \!deb,\!rpm,\!test,\!tarball
 
-FROM golang:1.22 as builder
+FROM golang:1.22.9 as builder
 COPY . /go/src/github.com/newrelic/nri-jmx/
 RUN cd /go/src/github.com/newrelic/nri-jmx && \
     make && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm
+FROM golang:1.22.9-bookworm
 
 ARG GH_VERSION='2.0.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-jmx
 
-go 1.22
+go 1.22.9
 
 require (
 	github.com/kr/pretty v0.3.0

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.22.9 as builder
 ARG CGO_ENABLED=0
 ARG NRJMX_VERSION
 WORKDIR /go/src/github.com/newrelic/nri-jmx


### PR DESCRIPTION
Added patch to the GoLang versions in `Docker` and `go.mod` files to ensure Renovate Auto merges PRs whenever a new GoLang patch version is released. 