### PR TITLE
Add Event Triggers to Re-Polinter workflow

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -2,6 +2,10 @@
 # workflow_dispatch to work properly
 name: Repolinter Action
 
+on:
+  push:
+  workflow_dispatch:
+
 jobs:
   repolinter:
     uses: newrelic/coreint-automation/.github/workflows/reusable_repolinter.yaml@v3


### PR DESCRIPTION
Added on push, workflow_dispatch event triggers for Re-Polinter workflow to fix this [error](https://github.com/newrelic/nri-jmx/actions/runs/12253693463#:~:text=No%20event%20triggers%20defined%20in%20%60on%60)