### PR TITLE
Promote a new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### bugfix
+- Updated go to v1.22.9
+
 ## 2.5.0
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,13 @@ integration-test:
 	@docker compose -f test/integration/docker-compose.yml up -d --build
 	@go test -v -tags=integration ./test/integration/. -count=1 ; (ret=$$?; docker compose -f test/integration/docker-compose.yml down && exit $$ret)
 
+# rt-update-changelog runs the release-toolkit run.sh script by piping it into bash to update the CHANGELOG.md.
+# It also passes down to the script all the flags added to the make target. To check all the accepted flags,
+# see: https://github.com/newrelic/release-toolkit/blob/main/contrib/ohi-release-notes/run.sh
+#  e.g. `make rt-update-changelog -- -v`
+rt-update-changelog:
+	curl "https://raw.githubusercontent.com/newrelic/release-toolkit/v1/contrib/ohi-release-notes/run.sh" | bash -s -- $(filter-out $@,$(MAKECMDGOALS))
+
 # Include thematic Makefiles
 include $(CURDIR)/build/ci.mk
 include $(CURDIR)/build/release.mk


### PR DESCRIPTION
- Add the latest go bump to the changelog to promote a new release 
- Add release-toolkit make target for local execution