### PR TITLE
NR-403516: Move all pipelines from ubuntu-20 runners to ubuntu-latest

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   test-integration-nix:
     name: Run integration tests on *Nix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
 
 env:
-  NRJMX_VERSION: '2.8.0' # Renovate automatically updates this dependencies to the latest release version. It will automatically merge minor and patch versions, while raising a pull request for major version updates.
+  NRJMX_VERSION: '2.7.0' # Renovate automatically updates this dependencies to the latest release version. It will automatically merge minor and patch versions, while raising a pull request for major version updates.
 
 jobs:
   test-integration-nix:

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -14,7 +14,7 @@ jobs:
   # can't run this step inside of container because of tests specific
   test-integration-nix:
     name: Run integration tests on *Nix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  NRJMX_VERSION: '2.8.0' # Renovate automatically updates this dependencies to the latest release version. It will automatically merge minor and patch versions, while raising a pull request for major version updates.
+  NRJMX_VERSION: '2.7.0' # Renovate automatically updates this dependencies to the latest release version. It will automatically merge minor and patch versions, while raising a pull request for major version updates.
 
 jobs:
   # can't run this step inside of container because of tests specific


### PR DESCRIPTION
### Context

This pull request is driven by the upcoming deprecation of the Ubuntu 20.04 Actions runner image. GitHub has announced the following timeline for deprecation:

- **Deprecation Start Date**: 2025-02-01
- **Full Unsupported Date**: 2025-04-15

Given these dates, it is crucial to transition to supported runner images to ensure that our CI/CD pipelines do not encounter disruptions.

### Change Description

- **Objective**: Update all pipelines to use the `ubuntu-latest` runner image instead of the soon-to-be deprecated `ubuntu-20.xx`.
- **Background**: By updating to `ubuntu-latest`, we align our workflows with the latest stable and supported environment that GitHub provides. 
- **Impact**: Workflows using the `ubuntu-20.04` image label should be updated to `ubuntu-latest`.

