### PR TITLE
fix: module path

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/nri-jmx/internal/tools
+module github.com/newrelic/nri-jmx/internal/tools
 
 go 1.24.4
 


### PR DESCRIPTION
- fix: go module path convention (to correctly identify Repository Ownership and Namespace)