### PR TITLE
ci: update Go to v1.26.2 and Windows build to use go-winres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN git clone https://github.com/newrelic/nrjmx.git && \
     cd nrjmx && \
     mvn package -DskipTests -P \!deb,\!rpm,\!test,\!tarball
 
-FROM golang:1.25.9 as builder
+FROM golang:1.26.2-bookworm as builder
 COPY . /go/src/github.com/newrelic/nri-jmx/
 RUN cd /go/src/github.com/newrelic/nri-jmx && \
     make && \

--- a/build/release.mk
+++ b/build/release.mk
@@ -16,13 +16,14 @@ $(GORELEASER_BIN): bin
 .PHONY : release/clean
 release/clean:
 	@echo "===> $(INTEGRATION) === [release/clean] remove build metadata files"
-	rm -fv $(CURDIR)/src/versioninfo.json
-	rm -fv $(CURDIR)/src/resource.syso
+	rm -fv $(CURDIR)/winres/winres.json
+	rm -fv $(CURDIR)/src/rsrc_windows_386.syso
+	rm -fv $(CURDIR)/src/rsrc_windows_amd64.syso
 
 .PHONY : release/deps
 release/deps: $(GORELEASER_BIN)
-	@echo "===> $(INTEGRATION) === [release/deps] install goversioninfo"
-	@cd $(TOOLS_MOD_DIR) && go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo
+	@echo "===> $(INTEGRATION) === [release/deps] install go-winres"
+	@go install github.com/tc-hib/go-winres@latest
 
 .PHONY : release/build
 release/build: release/deps release/clean

--- a/build/windows/set_exe_properties.sh
+++ b/build/windows/set_exe_properties.sh
@@ -24,6 +24,8 @@ BuildVersion='0'
 Year=$(date +"%Y")
 INTEGRATION_EXE="nri-${INTEGRATION}.exe"
 
+mkdir -p ./winres
+
 sed \
   -e "s/{MajorVersion}/$MajorVersion/g" \
   -e "s/{MinorVersion}/$MinorVersion/g" \
@@ -32,8 +34,6 @@ sed \
   -e "s/{Year}/$Year/g" \
   -e "s/{Integration}/nri-$INTEGRATION/g" \
   -e "s/{IntegrationExe}/$INTEGRATION_EXE/g" \
-   ./build/windows/versioninfo.json.template > ./src/versioninfo.json
+   ./build/windows/winres.json.template > ./winres/winres.json
 
-# todo: do we need this export line
-export PATH="$PATH:/go/bin"
-go generate github.com/newrelic/nri-${INTEGRATION}/src/
+go-winres make --arch 386,amd64 --out ./src/rsrc

--- a/build/windows/winres.json.template
+++ b/build/windows/winres.json.template
@@ -1,0 +1,28 @@
+{
+	"RT_VERSION": {
+		"#1": {
+			"0000": {
+				"fixed": {
+					"file_version": "{MajorVersion}.{MinorVersion}.{PatchVersion}.{BuildVersion}",
+					"product_version": "{MajorVersion}.{MinorVersion}.{PatchVersion}.{BuildVersion}"
+				},
+				"info": {
+					"0409": {
+						"Comments": "(c) {Year} New Relic, Inc.",
+						"CompanyName": "New Relic, Inc.",
+						"FileDescription": "",
+						"FileVersion": "{MajorVersion}.{MinorVersion}.{PatchVersion}.{BuildVersion}",
+						"InternalName": "{Integration}",
+						"LegalCopyright": "(c) {Year} New Relic, Inc.",
+						"LegalTrademarks": "",
+						"OriginalFilename": "{IntegrationExe}",
+						"PrivateBuild": "",
+						"ProductName": "New Relic Infrastructure Integration, {Integration}",
+						"ProductVersion": "{MajorVersion}.{MinorVersion}.{PatchVersion}.{BuildVersion}",
+						"SpecialBuild": ""
+					}
+				}
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-jmx
 
-go 1.25.9
+go 1.26.2
 
 require (
 	github.com/kr/pretty v0.3.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-jmx/internal/tools
 
-go 1.25.9
+go 1.26.2
 
 require github.com/josephspurrier/goversioninfo v1.5.0
 

--- a/src/jmx.go
+++ b/src/jmx.go
@@ -1,4 +1,3 @@
-//go:generate goversioninfo
 /*
  * Copyright 2022 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-bookworm as builder
+FROM golang:1.26.2 as builder
 ARG CGO_ENABLED=0
 ARG NRJMX_VERSION
 WORKDIR /go/src/github.com/newrelic/nri-jmx

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9 as builder
+FROM golang:1.26.2-bookworm as builder
 ARG CGO_ENABLED=0
 ARG NRJMX_VERSION
 WORKDIR /go/src/github.com/newrelic/nri-jmx

--- a/test/integration/jmx_test.go
+++ b/test/integration/jmx_test.go
@@ -130,7 +130,7 @@ func TestJMXIntegration_ShowVersion(t *testing.T) {
 	assert.Empty(t, stderr, "unexpected stderr")
 	assert.NoError(t, err, "Unexpected error")
 
-	expectedOutMessage := "New Relic Jmx integration Version: 0\\.0\\.0, Platform: linux/(amd|arm)64, GoVersion: go1\\.25\\.[0-9]+, GitCommit: , BuildDate:"
+	expectedOutMessage := "New Relic Jmx integration Version: 0\\.0\\.0, Platform: linux/(amd|arm)64, GoVersion: go1\\.[0-9]+\\.[0-9]+, GitCommit: , BuildDate:"
 	assert.Regexp(t, regexp.MustCompile(expectedOutMessage), stdout)
 }
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-jmx/tools
 
-go 1.25.9
+go 1.26.2
 
 require github.com/golangci/golangci-lint v1.64.8
 


### PR DESCRIPTION
## Summary

- Update Go directive in `go.mod` to v1.26.2
- Replace `goversioninfo` with `go-winres` for Windows exe metadata generation
- Add `build/windows/winres.json.template` (replaces `versioninfo.json.template`)
- Remove `//go:generate goversioninfo` directive from main Go source file
- Update Golang base image version in Dockerfiles to `1.26.2-bookworm`
- Run `go mod tidy` to update `go.sum`

## Test plan

- [ ] CI passes on this branch
- [ ] Windows build produces correct `.exe` metadata using `go-winres`
- [ ] Go 1.26.2 compilation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)