### PR TITLE
chore: update changelog for otel v1.41.0 security fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### 🛡️ Security notices
+### security
 - Upgraded `go.opentelemetry.io/otel` from v1.40.0 to v1.41.0 to fix [GHSA-mh2q-q3fh-2475](https://github.com/advisories/GHSA-mh2q-q3fh-2475) (High severity)
 
 ## v3.14.0 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### 🛡️ Security notices
+- Upgraded `go.opentelemetry.io/otel` from v1.40.0 to v1.41.0 to fix [GHSA-mh2q-q3fh-2475](https://github.com/advisories/GHSA-mh2q-q3fh-2475) (High severity)
+
 ## v3.14.0 - 2026-05-18
 
 ### 🛡️ Security notices


### PR DESCRIPTION
## Summary
- Adds changelog entry for the `go.opentelemetry.io/otel` upgrade from v1.40.0 to v1.41.0
- Documents fix for [GHSA-mh2q-q3fh-2475](https://github.com/advisories/GHSA-mh2q-q3fh-2475) (High severity)

## Test plan
- [x] Verify changelog format matches existing entries